### PR TITLE
Coords

### DIFF
--- a/src/lib/coords.test.ts
+++ b/src/lib/coords.test.ts
@@ -1,0 +1,10 @@
+import { type Coords } from "./coords";
+
+describe("coords tuple", () => {
+  test("should create coords", () => {
+    const position: Coords = [3, 4];
+
+    expect(position[0]).toBe(3);
+    expect(position[1]).toBe(4);
+  });
+});

--- a/src/lib/coords.test.ts
+++ b/src/lib/coords.test.ts
@@ -1,4 +1,4 @@
-import { type Coords } from "./coords";
+import { convertCoords, type Coords } from "./coords";
 
 describe("coords tuple", () => {
   test("should create coords", () => {
@@ -6,5 +6,26 @@ describe("coords tuple", () => {
 
     expect(position[0]).toBe(3);
     expect(position[1]).toBe(4);
+  });
+
+  test("should return Coords converter given board dimensions", () => {
+    const dimensions: Coords = [4, 5];
+
+    const toIndex = convertCoords(dimensions);
+
+    expect(toIndex).not.toBeNull();
+  });
+});
+
+describe("convert coords to index", () => {
+  const dimensions: Coords = [4, 5];
+  const toIndex = convertCoords(dimensions);
+
+  test.each([
+    [[0, 0], 0],
+    [[0, 1], 4],
+    [[3, 4], 19],
+  ])(`should convert coords(%o) -> index: %i`, (coords: Coords, expected) => {
+    expect(toIndex(coords)).toBe(expected);
   });
 });

--- a/src/lib/coords.test.ts
+++ b/src/lib/coords.test.ts
@@ -1,4 +1,4 @@
-import { convertCoords, type Coords } from "./coords";
+import { convertCoords, convertIndex, type Coords } from "./coords";
 
 describe("coords tuple", () => {
   test("should create coords", () => {
@@ -27,5 +27,18 @@ describe("convert coords to index", () => {
     [[3, 4], 19],
   ])(`should convert coords(%o) -> index: %i`, (coords: Coords, expected) => {
     expect(toIndex(coords)).toBe(expected);
+  });
+});
+
+describe("convert index to coords", () => {
+  const dimensions: Coords = [5, 10];
+  const toCoords = convertIndex(dimensions);
+
+  test.each([
+    [0, [0, 0]],
+    [22, [2, 4]],
+    [49, [4, 9]],
+  ])(`should convert index: %i -> %o`, (index, expected: Coords) => {
+    expect(toCoords(index)).toEqual(expected);
   });
 });

--- a/src/lib/coords.ts
+++ b/src/lib/coords.ts
@@ -1,0 +1,3 @@
+type Coords = [x: number, y: number];
+
+export type { Coords };

--- a/src/lib/coords.ts
+++ b/src/lib/coords.ts
@@ -1,3 +1,14 @@
 type Coords = [x: number, y: number];
 
+function convertCoords(dimensions: Coords) {
+  const [width] = dimensions;
+
+  return function (coords: Coords) {
+    const [x, y] = coords;
+
+    return y * width + x;
+  };
+}
+
 export type { Coords };
+export { convertCoords };

--- a/src/lib/coords.ts
+++ b/src/lib/coords.ts
@@ -10,5 +10,16 @@ function convertCoords(dimensions: Coords) {
   };
 }
 
+function convertIndex(dimensions: Coords) {
+  const [width] = dimensions;
+
+  return function (index: number) {
+    const x = index % width;
+    const y = Math.floor(index / width);
+
+    return [x, y];
+  };
+}
+
+export { convertCoords, convertIndex };
 export type { Coords };
-export { convertCoords };


### PR DESCRIPTION
represented board coordinates as a Coords tuple type ([x: number, y: number]) for conciseness for issue #1 